### PR TITLE
remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @actions/actions-runtime


### PR DESCRIPTION
template repositories shouldn't contain CODEOWNERS.
It doesn't work the repository generated by the template.